### PR TITLE
Add cxf parent pom imports, cxf parent pom now lists cxf projects as dependencyManagement entries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,13 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf</artifactId>
+                <version>${version.cxf}</version>
+                <type>pom</type>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.hawt</groupId>
                 <artifactId>project</artifactId>
                 <version>${version.hawtio}</version>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-9112

I think we should add the cxf parent pom here as a BOM.    One of the changes I made in 7.1 was adding all of the cxf-* artifacts into the cxf parent as dependencyManagement entries - we should be importing these in the redhat-fuse BOM as imports.