### PR TITLE
ENTESB-9274 Add spring-boot-dependencies to fuse spring boot bom

### DIFF
--- a/fuse-springboot/fuse-springboot-bom/pom.xml
+++ b/fuse-springboot/fuse-springboot-bom/pom.xml
@@ -50,6 +50,33 @@
                 <type>pom</type>
             </dependency>
 
+            <!-- Narayana Spring Boot dependencies -->
+            <dependency>
+                <groupId>me.snowdrop</groupId>
+                <artifactId>narayana-spring-boot-starter</artifactId>
+                <version>${version.narayana.spring.boot}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>me.snowdrop</groupId>
+                <artifactId>narayana-spring-boot-recovery-controller</artifactId>
+                <version>${version.narayana.spring.boot}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>me.snowdrop</groupId>
+                <artifactId>narayana-spring-boot-core</artifactId>
+                <version>${version.narayana.spring.boot}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>me.snowdrop</groupId>
+                <artifactId>narayana-spring-boot-starter-it</artifactId>
+                <version>${version.narayana.spring.boot}</version>
+            </dependency>
+
+
+
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,24 +36,26 @@
         <enforcer.pluginVersions.banSnapshots>false</enforcer.pluginVersions.banSnapshots>
 
         <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
-        <version.camel>2.21.0.fuse-710016</version.camel>
-        <version.camel.extra>2.21.0.fuse-710016</version.camel.extra>
-        <version.cxf>3.1.11.fuse-710018</version.cxf>
-        <version.fabric8>3.0.11.fuse-710016</version.fabric8>
-        <version.fabric8.maven.plugin>3.5.33.fuse-710016</version.fabric8.maven.plugin>
-        <version.bom.fuse>7.1.0.fuse-710016</version.bom.fuse>
-        <version.karaf>4.2.0.fuse-710020</version.karaf>
-        <version.bom.wildfly.camel>5.2.0.fuse-710014</version.bom.wildfly.camel>
-        <version.fusesource.camel.sap>7.1.0.fuse-710016</version.fusesource.camel.sap>
-        <karaf.plugin.version>4.2.0.fuse-710020</karaf.plugin.version>
+        <version.camel>2.21.0.fuse-720006</version.camel>
+        <version.camel.extra>7.2.0.fuse-720006</version.camel.extra>
+        <version.cxf>3.1.11.fuse-720008</version.cxf>
+        <version.fabric8>3.0.11.fuse-720002</version.fabric8>
+        <version.fabric8.maven.plugin>3.5.33.fuse-720002</version.fabric8.maven.plugin>
+        <version.bom.fuse>7.2.0.fuse-720005</version.bom.fuse>
+        <version.karaf>4.2.0.fuse-720009</version.karaf>
+        <version.bom.wildfly.camel>5.2.0.fuse-720002</version.bom.wildfly.camel>
+        <version.fusesource.camel.sap>7.2.0.fuse-720006</version.fusesource.camel.sap>
+        <karaf.plugin.version>4.2.0.fuse-720009</karaf.plugin.version>
 
-        <version.hawtio>2.0.0.fuse-710016</version.hawtio>
-        <version.hawtio.online>1.0.0.fuse-710016</version.hawtio.online>
-        
-        <version.kubernetes.model>2.0.10.fuse-710001</version.kubernetes.model>
-        <version.kubernetes.client>3.1.4.fuse-710001</version.kubernetes.client>
+        <version.hawtio>2.0.0.fuse-720006</version.hawtio>
+        <version.hawtio.online>1.0.0.fuse-720005</version.hawtio.online>
 
-        <version.docker.maven.plugin>0.23.0.fuse-710016</version.docker.maven.plugin>
+        <version.narayana.spring.boot>1.0.2.fuse-720002</version.narayana.spring.boot>
+
+        <version.kubernetes.model>2.0.9.fuse-720004</version.kubernetes.model>
+        <version.kubernetes.client>3.1.4.fuse-720003</version.kubernetes.client>
+
+        <version.docker.maven.plugin>0.23.0.fuse-720002</version.docker.maven.plugin>
 
         <!--
           CONVENTIONS:


### PR DESCRIPTION
I think we should add spring-boot-dependencies to the fuse spring boot bom.

Also, changed versions to match the first 7.2 build.