### PR TITLE
ENTESB-9637 Exclude com.google.guava from the fabric8 spring-boot BOM for the cxf-java2swagger plugin

### DIFF
--- a/fuse-maven-plugins/cxf-java2swagger-plugin/pom.xml
+++ b/fuse-maven-plugins/cxf-java2swagger-plugin/pom.xml
@@ -38,6 +38,12 @@
                 <version>${version.fabric8}</version>
                 <scope>import</scope>
                 <type>pom</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-9637

com.google.guava:guava:18.0 was coming in through the fabric8 spring-boot BOM during the plugin repackaging, and that interferes with the guava necessary for the cxf-java2swagger maven plugin (com.google.guava:guava:20.0).    Excluding it from coming in fixes the issue.