### PR TITLE
ENTESB-9642 Repackage the maven-bundle-plugin in redhat-fuse

### DIFF
--- a/fuse-maven-plugins/maven-bundle-plugin/pom.xml
+++ b/fuse-maven-plugins/maven-bundle-plugin/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2017 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.redhat-fuse</groupId>
+        <artifactId>fuse-maven-plugins</artifactId>
+        <version>7.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>maven-bundle-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Red Hat Fuse :: ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>${version.felix.bundle-plugin}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>2.2</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/fuse-maven-plugins/pom.xml
+++ b/fuse-maven-plugins/pom.xml
@@ -34,6 +34,8 @@
         <module>spring-boot-maven-plugin</module>
         <module>fabric8-maven-plugin</module>
 
+        <module>maven-bundle-plugin</module>
+
         <module>karaf-maven-plugin</module>
         <module>karaf-services-maven-plugin</module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
 
         <version.apicurito>1.0.0.fuse-720010</version.apicurito>
 
+        <version.felix.bundle-plugin>3.3.0</version.felix.bundle-plugin>
+
         <!--
           CONVENTIONS:
           - A version property must be specified in the format "version.{groupId}", optionally with a suffix to make it unique.


### PR DESCRIPTION
@chirino I started taking a look at converting over the karaf quickstarts to the BOM and noticed that they used maven-bundle-plugin basically everywhere.     I think it makes sense to repackage it so that we standardize on version and so we don't have to declare a version for the maven-bundle-plugin in the karaf quickstarts - it'd come in through the redhat-fuse BOM import.     Does that make sense?   I know we aren't building the maven-bundle-plugin but I think we made an exception for the spring-boot-maven-plugin too.