### PR TITLE
ENTESB-9112 Missing CXF dependencies in fabric8-project-bom-camel-spring-boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf</artifactId>
+                <artifactId>cxf-parent</artifactId>
                 <version>${version.cxf}</version>
                 <type>pom</type>
                 <scope>provided</scope>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-9112