### PR TITLE
Import cxf parent like we do in the karaf bom

### DIFF
--- a/fuse-springboot/fuse-springboot-bom/pom.xml
+++ b/fuse-springboot/fuse-springboot-bom/pom.xml
@@ -50,6 +50,14 @@
                 <type>pom</type>
             </dependency>
 
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-parent</artifactId>
+                <version>${version.cxf}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
We need to import the cxf-parent in spring-boot so that we get the correct versions of cxf artifacts from that BOM.