### PR TITLE
Use static version of f-m-p

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <version.cxf>3.2.7.fuse-sb2-750003</version.cxf>
 
         <version.fabric8>3.0.11.fuse-750006</version.fabric8>
-        <version.fabric8.maven.plugin>3.5.33.fuse-750006</version.fabric8.maven.plugin>
+        <version.fabric8.maven.plugin>3.5.33.fuse-740029-redhat-00001</version.fabric8.maven.plugin>
         <version.fusesource.camel.sap>7.5.0.fuse-sb2-750003</version.fusesource.camel.sap>
 
         <version.hawtio>2.0.0.fuse-sb2-750002</version.hawtio>


### PR DESCRIPTION
For the spring-boot 2 build, we aren't building f-m-p as part of the spring boot 2 build.    We can't build f-m-p as part of the build because of the differences in kubernetes-client (we build with 4.1.0 in sb2, we use 3.0 in sb1), and the API differences cause issues with building f-m-p.

We should just use the 7.4 version of f-m-p for now, and we'll do the same thing we did in PNC and put the 7.5 version in in PNC.