### PR TITLE
ENTESB-11007: Fix some jackson-databind related CVEs

### DIFF
--- a/fuse-springboot/fuse-springboot-bom/pom.xml
+++ b/fuse-springboot/fuse-springboot-bom/pom.xml
@@ -32,6 +32,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Bump jackson to versions newer than Spring Boot curated ones in order to prevent some CVEs -->            
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.9.10.20191020</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Fuse BOM to import all non-plugin dependencies -->
             <dependency>
                 <groupId>org.jboss.redhat-fuse</groupId>


### PR DESCRIPTION
QE is pushing to override jackson versions at [fuse-springboot-bom level.](https://issues.redhat.com/browse/ENTESB-12974) Conversely, I plan to remove it from lower level in Spring Boot 2 quickstarts in 7.6 and 7.7.