### PR TITLE
ENTESB-13929 Remove hawtio-online from redhat-fuse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <karaf.plugin.version>4.2.6.fuse-770010</karaf.plugin.version>
 
         <version.hawtio>2.0.0.fuse-770007</version.hawtio>
-        <version.hawtio.online>1.0.0.fuse-750011</version.hawtio.online>
 
         <version.kubernetes.model>2.0.10.fuse-770006</version.kubernetes.model>
         <version.kubernetes.client>3.1.12.fuse-770009</version.kubernetes.client>
@@ -266,12 +265,6 @@
                 <groupId>org.apache-extras.camel-extra</groupId>
                 <artifactId>camel-parent</artifactId>
                 <version>${version.camel.extra}</version>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.hawt</groupId>
-                <artifactId>hawtio-online</artifactId>
-                <version>${version.hawtio.online}</version>
                 <type>pom</type>
             </dependency>
             <dependency>


### PR DESCRIPTION
Remove hawtio-online from redhat-fuse.   hawtio-online builds after redhat-fuse and has for a number of releases now, and the build ordering there means that it will never align to the productized version of hawtio-online.    We should remove it because I do not think it is necessary.