### PR TITLE
Add openshift-maven-plugin to redhat-fuse

### DIFF
--- a/fuse-maven-plugins/openshift-maven-plugin/pom.xml
+++ b/fuse-maven-plugins/openshift-maven-plugin/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2017 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.redhat-fuse</groupId>
+        <artifactId>fuse-maven-plugins</artifactId>
+        <version>7.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>openshift-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Red Hat Fuse :: ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${version.openshift.maven.plugin}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
 
         <version.felix.bundle-plugin>3.5.1</version.felix.bundle-plugin>
 
+        <version.openshift.maven.plugin>1.0.0-rc-1</version.openshift.maven.plugin>
+
         <rhoar.version>2.1.13.Final-redhat-00001</rhoar.version>
         <spring.security.version>5.1.10.RELEASE</spring.security.version>
         <version.snakeyaml>1.26</version.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-14419 suggests we need to deprecate fabric8-maven-plugin before switching over to openshift-maven-plugin, but I'd like to introduce it as a repackaged plugin so that we can begin to test it.