### PR TITLE
ENTESB-15089 Change kafka to use 212 artifacts, remove jetty artifacts which don't exist for 9.4.30.v20200611

### DIFF
--- a/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
+++ b/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
@@ -1167,12 +1167,12 @@
 
 			<dependency>
 				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka_2.11</artifactId>
+				<artifactId>kafka_2.12</artifactId>
 				<version>${version.kafka.upstream}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka-streams-scala_2.11</artifactId>
+				<artifactId>kafka-streams-scala_2.12</artifactId>
 				<version>${version.kafka.upstream}</version>
 			</dependency>
 			<dependency>
@@ -1457,16 +1457,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.eclipse.jetty.cdi</groupId>
-				<artifactId>cdi-core</artifactId>
-				<version>${version.org.eclipse.jetty}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty.cdi</groupId>
-				<artifactId>cdi-servlet</artifactId>
-				<version>${version.org.eclipse.jetty}</version>
-			</dependency>
-			<dependency>
 				<groupId>org.eclipse.jetty.fcgi</groupId>
 				<artifactId>fcgi-client</artifactId>
 				<version>${version.org.eclipse.jetty}</version>
@@ -1509,11 +1499,6 @@
 			<dependency>
 				<groupId>org.eclipse.jetty.memcached</groupId>
 				<artifactId>jetty-memcached-sessions</artifactId>
-				<version>${version.org.eclipse.jetty}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty.orbit</groupId>
-				<artifactId>javax.servlet.jsp</artifactId>
 				<version>${version.org.eclipse.jetty}</version>
 			</dependency>
 			<dependency>
@@ -1743,11 +1728,6 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-quickstart</artifactId>
-				<version>${version.org.eclipse.jetty}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-reactive-httpclient</artifactId>
 				<version>${version.org.eclipse.jetty}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Upgrade kafka artifacts to match what's shipped in camel.
The jetty artifacts here were committed as part of ENTESB-13036, but they don't exist for the jetty version chosen 9.4.30.v20200611 - some have been removed since 9.4.19 and others don't seem to have ever existed for jetty 9..   I've checked all of them, and camel is not using them either.    @oscerd - I think we're safe removing these as they don't exist, can you think of any issues here?