### PR TITLE
Use ${project.version} for repackage-maven-plugin

### DIFF
--- a/fuse-maven-plugins/pom.xml
+++ b/fuse-maven-plugins/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.jboss.redhat-fuse</groupId>
                 <artifactId>repackage-maven-plugin</artifactId>
-                <version>7.8.0.fuse-sb2-780038-redhat-00001</version>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <id>repackage</id>


### PR DESCRIPTION
@grgrzybek is ${project.version} what we want here or is there some dependency that we use the GA version for repackage-maven-plugin?   