### PR TITLE
[ENTESB-16892] Elastic Search Rest cannot be used on SpringBoot

### DIFF
--- a/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
+++ b/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
@@ -541,6 +541,21 @@
 				<artifactId>infinispan-server-infinispan</artifactId>
 				<version>${infinispan.version}</version>
 			</dependency>
+			<dependency>
+        			<groupId>org.elasticsearch</groupId>
+        			<artifactId>elasticsearch</artifactId>
+        			<version>${version.elasticsearch-rest}</version>
+      			</dependency>
+			<dependency>
+        			<groupId>org.elasticsearch.client</groupId>
+        			<artifactId>elasticsearch-rest-client</artifactId>
+        			<version>${version.elasticsearch-rest}</version>
+      			</dependency>
+			<dependency>
+        			<groupId>org.elasticsearch.client</groupId>
+        			<artifactId>elasticsearch-rest-high-level-client</artifactId>
+        			<version>${version.elasticsearch-rest}</version>
+			</dependency>
 
 			<!-- Spring Boot -->
 <!--			<dependency>-->

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,8 @@
         <version.javax.xml.bind>2.3.0</version.javax.xml.bind>
         <version.org.jboss.xnio>3.5.9.Final</version.org.jboss.xnio>
 
+        <version.elasticsearch-rest>6.4.2</version.elasticsearch-rest>
+
         <!-- test frameworks versions -->
         <arquillian.version>1.4.1.Final</arquillian.version>
         <arquillian.cube.version>1.18.2</arquillian.cube.version>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-16892

When camel-elasticsearch-rest-starter is generated from archetype, it contains:
```
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>org.jboss.redhat-fuse</groupId>
            <artifactId>fuse-springboot-bom</artifactId>
            <version>${fuse.bom.version}</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>
```

in its pom.xml. Spring-boot-dependencies 2.3.4.RELEASE on the import path imports Elasticsearch 7.6.2. However, camel-elasticsearch-rest-starter needs Elasticsearch 6.4.2.

This solution sets the correct version for the dependencies before spring-boot-dependencies is loaded.