### PR TITLE
ENTESB-17372 Adding atlasmap to dependencyManagement

### DIFF
--- a/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
+++ b/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
@@ -654,6 +654,49 @@
 				<version>${version.fabric8}</version>
 				<scope>test</scope>
 			</dependency>
+			
+			<!-- Atlasmap -->
+			<dependency>
+				<!-- camel-atlasmap component for Camel 2.x -->
+				<groupId>io.atlasmap</groupId>
+				<artifactId>camel-atlasmap<</artifactId>
+				<version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.atlasmap</groupId>
+				<artifactId>atlasmap-api<</artifactId>
+				<version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.atlasmap</groupId>
+				<artifactId>atlasmap-core<</artifactId>
+				<version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+			      <groupId>io.atlasmap</groupId>
+			      <artifactId>atlas-dfdl-module</artifactId>
+			      <version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+			      <groupId>io.atlasmap</groupId>
+			      <artifactId>atlas-java-module</artifactId>
+			      <version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+			      <groupId>io.atlasmap</groupId>
+			      <artifactId>atlas-json-module</artifactId>
+			      <version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+			      <groupId>io.atlasmap</groupId>
+			      <artifactId>atlas-xml-module</artifactId>
+			      <version>${version.atlasmap}</version>
+			</dependency>
+			<dependency>
+			      <groupId>io.atlasmap</groupId>
+			      <artifactId>atlas-csv-module</artifactId>
+			      <version>${version.atlasmap}</version>
+			</dependency>
 
 			<!-- OVERRIDES -->
 			<!-- Hibernate Validator -->

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <spring.boot.version>2.3.12.RELEASE</spring.boot.version>
         <spring.security.version>5.3.9.RELEASE</spring.security.version>
         <version.snakeyaml>1.28</version.snakeyaml>
+        
+        <version.atlasmap>2.2.3.fuse-790003-redhat-00001</version.atlasmap>
 
         <!-- Overridden from snowdrop Spring Boot BOM-->
         <hibernate.version>5.3.21.Final-redhat-00001</hibernate.version>


### PR DESCRIPTION
The goal here is to provide easier way to use Atlasmap with Fuse BOM. See https://issues.redhat.com/browse/ENTESB-17372

We'd like this to be included in Fuse 7.10.x. Is this the right branch?