### PR TITLE
Update openshift-maven-plugin version to 1.4.0 to match atlasmap, update versions of other projects to current 7.10 builds to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,33 +35,33 @@
         <!-- Build properties (overridable in profiles) -->
         <enforcer.pluginVersions.banSnapshots>false</enforcer.pluginVersions.banSnapshots>
 
-        <version.camel>2.23.2.fuse-780032</version.camel>
-        <version.camel.extra>2.23.2.fuse-sb2-780032</version.camel.extra>
-        <version.cxf>3.3.6.fuse-780025</version.cxf>
-        <version.cxf.xjc-utils>3.3.1.fuse-780003</version.cxf.xjc-utils>
+        <version.camel>2.23.2.fuse-7_10_0-00008</version.camel>
+        <version.camel.extra>2.23.2.fuse-sb2-7_10_0-00008</version.camel.extra>
+        <version.cxf>3.3.6.fuse-7_10_0-00011</version.cxf>
+        <version.cxf.xjc-utils>3.3.1.fuse-7_10_0-00006</version.cxf.xjc-utils>
 
         <version.fabric8>3.0.12</version.fabric8>
-        <version.fabric8.maven.plugin>4.3.0.fuse-780009</version.fabric8.maven.plugin>
-        <version.fuse-karaf>7.8.0.fuse-780031</version.fuse-karaf>
-        <version.karaf>4.2.9.fuse-780019</version.karaf>
-        <version.wildfly.camel>5.5.0.fuse-770010-redhat-00003</version.wildfly.camel>
-        <version.fusesource.camel.sap>7.8.0.fuse-sb2-780031</version.fusesource.camel.sap>
-        <karaf.plugin.version>4.2.9.fuse-780019</karaf.plugin.version>
+        <version.fabric8.maven.plugin>4.3.0.fuse-7_10_0-00004</version.fabric8.maven.plugin>
+        <version.fuse-karaf>7.10.0.fuse-7_10_0-00002</version.fuse-karaf>
+        <version.karaf>4.2.12.fuse-7_10_0-00002</version.karaf>
+        <version.wildfly.camel>5.8.0.fuse-7_10_0-00003</version.wildfly.camel>
+        <version.fusesource.camel.sap>7.10.0.fuse-sb2-7_10_0-00007</version.fusesource.camel.sap>
+        <karaf.plugin.version>4.2.12.fuse-7_10_0-00002</karaf.plugin.version>
 
-        <version.hawtio>2.0.0.fuse-sb2-780019</version.hawtio>
+        <version.hawtio>2.0.0.fuse-sb2-7_10_0-00007</version.hawtio>
 
         <version.kubernetes.model>4.6.2</version.kubernetes.model>
         <version.kubernetes.client>4.6.2</version.kubernetes.client>
 
-        <version.docker.maven.plugin>0.31.0.fuse-780001</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.31.0.fuse-7_10_0-00006</version.docker.maven.plugin>
 
-        <version.narayana-spring-boot>2.1.1.fuse-sb2-780030</version.narayana-spring-boot>
+        <version.narayana-spring-boot>2.1.1.fuse-sb2-7_10_0-00005</version.narayana-spring-boot>
 
         <version.spring-cloud-kubernetes>1.0.4.RELEASE</version.spring-cloud-kubernetes>
 
         <version.felix.bundle-plugin>3.5.1</version.felix.bundle-plugin>
 
-        <version.openshift.maven.plugin>1.3.0</version.openshift.maven.plugin>
+        <version.openshift.maven.plugin>1.4.0</version.openshift.maven.plugin>
 
         <spring.boot.version>2.3.12.RELEASE</spring.boot.version>
         <spring.security.version>5.3.9.RELEASE</spring.security.version>


### PR DESCRIPTION
@ffang @luigidemasi @rnetuka @grgrzybek Only real change here is upgrading openshift-maven-plugin version here to 1.4.0 to match the version used in atlasmap - is there any reason to not do this?

Upgraded versions of pipeline projects to test build.
