### PR TITLE
ENTESB-17312: CVE-2021-37136 netty-codec: Bzip2Decoder doesn't allow …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.commons-beanutils>1.9.4.redhat-00002</version.commons-beanutils>
         <version.commons-codec>1.15.0.redhat-00001</version.commons-codec>
         <version.commons-pool>1.6.0.redhat-10</version.commons-pool>
-        <version.netty>4.1.67.Final-redhat-00001</version.netty>
+        <version.netty>4.1.68.Final-redhat-00001</version.netty>
 
         <version.org.apache.commons.dbcp2>2.8.0</version.org.apache.commons.dbcp2>
         <version.org.apache.commons.lang3>3.12.0.redhat-00001</version.org.apache.commons.lang3>


### PR DESCRIPTION
…setting size restrictions for decompressed data [fuse-7]