### PR TITLE
Add relativePath, build fabric8-maven-plugin as a module from root pom

### DIFF
--- a/fuse-maven-plugins/fabric8-maven-plugin/pom.xml
+++ b/fuse-maven-plugins/fabric8-maven-plugin/pom.xml
@@ -24,6 +24,7 @@
         <groupId>org.jboss.redhat-fuse</groupId>
         <artifactId>redhat-fuse</artifactId>
         <version>7.9.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fabric8-maven-plugin</artifactId>

--- a/fuse-maven-plugins/pom.xml
+++ b/fuse-maven-plugins/pom.xml
@@ -32,7 +32,6 @@
 
     <modules>
         <module>spring-boot-maven-plugin</module>
-        <module>fabric8-maven-plugin</module>
         <module>openshift-maven-plugin</module>
 
         <module>karaf-maven-plugin</module>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <module>fuse-eap</module>
         <module>fuse-springboot</module>
         <module>fuse-maven-plugins</module>
+        <module>fuse-maven-plugins/fabric8-maven-plugin</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Add relativePath, build fabric8-maven-plugin as a module from root pom, fix build error here : https://ci-jenkins-csb-fuse.apps.ocp-c1.prod.psi.redhat.com/job/Fuse-7.10/job/productization-sb2-build/58/console