### PR TITLE
Cleanup pom

### DIFF
--- a/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
+++ b/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
@@ -1881,13 +1881,6 @@
 				<version>1.6.3.redhat-2</version>
 			</dependency>
 
-			<!-- somehow this is not imported from CXF's bom -->
-			<dependency>
-				<groupId>org.apache.cxf</groupId>
-				<artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
-				<version>${version.cxf}</version>
-			</dependency>
-
 			<!-- log4j2 -->
 
 			<dependency>


### PR DESCRIPTION
`cxf-spring-boot-starter-jaxrs` is already present in [cxf-parent pom](https://github.com/jboss-fuse/cxf/blob/3.2.x.redhat-7-x/parent/pom.xml#L1013-L1017)