### PR TITLE
ENTESB-19516 Removal of unproductized netty dependencies from the BOM

### DIFF
--- a/fuse-karaf/fabric8-project-bom-fuse-karaf/pom.xml
+++ b/fuse-karaf/fabric8-project-bom-fuse-karaf/pom.xml
@@ -173,24 +173,26 @@
                 <version>${version.netty}</version>
                 <classifier>linux-x86_64</classifier>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>${version.netty}</version>
-                <classifier>osx-x86_64</classifier>
-            </dependency>
+<!--			Removed because of https://issues.redhat.com/browse/ENTESB-19516-->
+<!--            <dependency>-->
+<!--                <groupId>io.netty</groupId>-->
+<!--                <artifactId>netty-transport-native-unix-common</artifactId>-->
+<!--                <version>${version.netty}</version>-->
+<!--                <classifier>osx-x86_64</classifier>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
                 <version>${version.netty}</version>
                 <classifier>linux-x86_64</classifier>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>${version.netty}</version>
-                <classifier>osx-x86_64</classifier>
-            </dependency>
+<!--			Removed because of https://issues.redhat.com/browse/ENTESB-19516-->
+<!--            <dependency>-->
+<!--                <groupId>io.netty</groupId>-->
+<!--                <artifactId>netty-transport-native-kqueue</artifactId>-->
+<!--                <version>${version.netty}</version>-->
+<!--                <classifier>osx-x86_64</classifier>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-classes-macos</artifactId>

--- a/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
+++ b/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
@@ -1419,24 +1419,26 @@
 				<version>${version.netty}</version>
 				<classifier>linux-x86_64</classifier>
 			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-transport-native-unix-common</artifactId>
-				<version>${version.netty}</version>
-				<classifier>osx-x86_64</classifier>
-			</dependency>
+<!--			Removed because of https://issues.redhat.com/browse/ENTESB-19516-->
+<!--			<dependency>-->
+<!--				<groupId>io.netty</groupId>-->
+<!--				<artifactId>netty-transport-native-unix-common</artifactId>-->
+<!--				<version>${version.netty}</version>-->
+<!--				<classifier>osx-x86_64</classifier>-->
+<!--			</dependency>-->
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-transport-native-epoll</artifactId>
 				<version>${version.netty}</version>
 				<classifier>linux-x86_64</classifier>
 			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-transport-native-kqueue</artifactId>
-				<version>${version.netty}</version>
-				<classifier>osx-x86_64</classifier>
-			</dependency>
+<!--			Removed because of https://issues.redhat.com/browse/ENTESB-19516-->
+<!--			<dependency>-->
+<!--				<groupId>io.netty</groupId>-->
+<!--				<artifactId>netty-transport-native-kqueue</artifactId>-->
+<!--				<version>${version.netty}</version>-->
+<!--				<classifier>osx-x86_64</classifier>-->
+<!--			</dependency>-->
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-resolver-dns-classes-macos</artifactId>


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ENTESB-19516

Completes https://github.com/jboss-fuse/redhat-fuse/pull/305.
There are another 2 dependencies with classifiers, which are not productized. I commented them out with the explanation.