### PR TITLE
[ENTESB-20742] Remove log4j-slf4j18-impl from managed dependencies, a…

### DIFF
--- a/fuse-eap/fuse-eap-bom/pom.xml
+++ b/fuse-eap/fuse-eap-bom/pom.xml
@@ -107,11 +107,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j18-impl</artifactId>
-                <version>${version.org.apache.logging.log4j2}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-taglib</artifactId>
                 <version>${version.org.apache.logging.log4j2}</version>
             </dependency>

--- a/fuse-karaf/fuse-karaf-bom/pom.xml
+++ b/fuse-karaf/fuse-karaf-bom/pom.xml
@@ -107,11 +107,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j18-impl</artifactId>
-                <version>${version.org.apache.logging.log4j2}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-taglib</artifactId>
                 <version>${version.org.apache.logging.log4j2}</version>
             </dependency>

--- a/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
+++ b/fuse-springboot/fabric8-camel-spring-boot-bom/pom.xml
@@ -1977,11 +1977,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-slf4j18-impl</artifactId>
-				<version>${version.org.apache.logging.log4j2}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-taglib</artifactId>
 				<version>${version.org.apache.logging.log4j2}</version>
 			</dependency>


### PR DESCRIPTION
…s there's no 2.19.0 version of this artifact